### PR TITLE
Switch from LibreOffice to OnlyOffice

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/CybercentreCanada/assemblyline-service-template.git",
-  "commit": "2f961bb22a68cd997efef36a7f41bbbe19b3dcf8",
+  "commit": "0b087951f5aa83414431a925ccd256f252875e32",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "__svc_name": "document-preview",
       "__repository": "assemblyline-service-document-preview",
       "__pkg_name": "document_preview",
-      "__class_name": "DocumentPreview",
+      "class_name": "DocumentPreview",
       "short_description": "This Assemblyline service renders documents for preview and performs OCR analysis for malicious content.",
       "short_description_fr": "Ce service d'Assemblyline exécute le rendement des documents pour prévisualisation et effectue une analyse OCR pour détecter les contenus malveillants.",
       "stage": "CORE",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "RunServiceOnce",
+            "name": "RunServiceOnce DocumentPreview",
             "type": "python",
             "request": "launch",
             "module": "assemblyline_v4_service.dev.run_service_once",
@@ -17,5 +17,20 @@
             ],
             "justMyCode": false,
         },
+        {
+            "name": "[Service] DocumentPreview - Privileged",
+            "type": "python",
+            "request": "launch",
+            "module": "assemblyline_v4_service.run_privileged_service",
+            "env": {
+                "SERVICE_MANIFEST_PATH": "service_manifest.yml",
+                "PRIVILEGED": "true",
+                "SERVICE_PATH": "document_preview.document_preview.DocumentPreview",
+                "TASKING_DIR": "/tmp/DocumentPreview"
+            },
+            "console": "internalConsole",
+            "cwd": "${workspaceFolder}",
+            "justMyCode": false,
+        }
     ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ We check for new pull requests every day and will merge them in once they have b
 
 # Guide de contribution d'Assemblyline
 
-Ce guide couvre les bases de la façon de contribuer au projet Assemblyline.
+Ce guide couvre les bases afin de contribuer au projet Assemblyline.
 
 Le code Python doit suivre les directives PEP8 définies ici:
 [Directives PEP8](https://www.python.org/dev/peps/pep-0008/).

--- a/document_preview/document_preview.py
+++ b/document_preview/document_preview.py
@@ -268,6 +268,11 @@ class DocumentPreview(ServiceBase):
         run_ocr_on_first_n_pages = request.get_param("run_ocr_on_first_n_pages")
         previews = [s for s in os.listdir(self.working_directory) if "output" in s]
 
+        if not previews:
+            # No previews found, unable to proceed
+            request.result = result
+            return
+
         def attach_images_to_section(run_ocr=False) -> str:
             extracted_text = ""
             for i, preview in enumerate(natsorted(previews)):

--- a/document_preview/document_preview.py
+++ b/document_preview/document_preview.py
@@ -40,7 +40,7 @@ def pdfinfo_from_path(fp: str):
         # Clean up spacing
         v = v.lstrip()
         pdfinfo[k] = v
-    pdfinfo
+    return pdfinfo
 
 
 def convert_from_path(fp: str, output_directory: str, first_page=1, last_page=None):

--- a/pkglist.txt
+++ b/pkglist.txt
@@ -2,7 +2,6 @@ calibre
 libemail-address-perl
 libemail-outlook-message-perl
 libgdiplus
-libreoffice
 poppler-utils
 tesseract-ocr
 unzip

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ pandas
 Pillow==10.3.0
 pytesseract
 selenium
-unoconv
 XlsxWriter

--- a/tests/results/44e593c98acaf52aee91c09fe00fa196668351783fc8a623fc1da5325635130f/result.json
+++ b/tests/results/44e593c98acaf52aee91c09fe00fa196668351783fc8a623fc1da5325635130f/result.json
@@ -10,12 +10,36 @@
             "img": {
               "description": "Here's the preview for page 0",
               "name": "page_000.png",
-              "sha256": "2014b88ea9d67b9229219aa3daf8a2dd84cbff0b79f4ea8eb5ad6f01a6197bbe"
+              "sha256": "35ae3b9b6477ab2d6a5e0f8a2d1db1b8c7780d6df7b1d2f1f67acbb8f8f57ab0"
             },
             "thumb": {
               "description": "Here's the preview for page 0 (thumbnail)",
               "name": "page_000.png.thumb",
-              "sha256": "2953efab8877f0bb30eece8f8d15ba88c5560a69ef47e12b82696d9e60720ef7"
+              "sha256": "0168b9e6b7d58d1a203531e2bd4dd84b90bd6205aaf766ece364ab7dc7869957"
+            }
+          },
+          {
+            "img": {
+              "description": "Here's the preview for page 1",
+              "name": "page_001.png",
+              "sha256": "b6d9ac977aa4b7f3309fc47b8bd211e0c769c03bd468e138770c05b3da67f1ac"
+            },
+            "thumb": {
+              "description": "Here's the preview for page 1 (thumbnail)",
+              "name": "page_001.png.thumb",
+              "sha256": "bb2b2f7dc95d5543db3f7f1dd05bf09764ebc7bbe3c9d726be9116be16f68b58"
+            }
+          },
+          {
+            "img": {
+              "description": "Here's the preview for page 2",
+              "name": "page_002.png",
+              "sha256": "f53a48cbbbecebb94680fb8d63bf1d230ed4cb1a62c3f2b0a0f1105a07d81896"
+            },
+            "thumb": {
+              "description": "Here's the preview for page 2 (thumbnail)",
+              "name": "page_002.png.thumb",
+              "sha256": "9a5619e2f72daaec7f56f552aa5d3cff336442388dcbf20cbd559872e4f4d07a"
             }
           }
         ],
@@ -35,12 +59,28 @@
     "extracted": [],
     "supplementary": [
       {
-        "name": "page_000.png",
-        "sha256": "2014b88ea9d67b9229219aa3daf8a2dd84cbff0b79f4ea8eb5ad6f01a6197bbe"
+        "name": "page_000.png.thumb",
+        "sha256": "0168b9e6b7d58d1a203531e2bd4dd84b90bd6205aaf766ece364ab7dc7869957"
       },
       {
-        "name": "page_000.png.thumb",
-        "sha256": "2953efab8877f0bb30eece8f8d15ba88c5560a69ef47e12b82696d9e60720ef7"
+        "name": "page_000.png",
+        "sha256": "35ae3b9b6477ab2d6a5e0f8a2d1db1b8c7780d6df7b1d2f1f67acbb8f8f57ab0"
+      },
+      {
+        "name": "page_002.png.thumb",
+        "sha256": "9a5619e2f72daaec7f56f552aa5d3cff336442388dcbf20cbd559872e4f4d07a"
+      },
+      {
+        "name": "page_001.png",
+        "sha256": "b6d9ac977aa4b7f3309fc47b8bd211e0c769c03bd468e138770c05b3da67f1ac"
+      },
+      {
+        "name": "page_001.png.thumb",
+        "sha256": "bb2b2f7dc95d5543db3f7f1dd05bf09764ebc7bbe3c9d726be9116be16f68b58"
+      },
+      {
+        "name": "page_002.png",
+        "sha256": "f53a48cbbbecebb94680fb8d63bf1d230ed4cb1a62c3f2b0a0f1105a07d81896"
       }
     ]
   },

--- a/tests/results/476ffe916dc810c30c864e4553eb2e6da8a7db9eeea18eceaeead43dc190d1a1/result.json
+++ b/tests/results/476ffe916dc810c30c864e4553eb2e6da8a7db9eeea18eceaeead43dc190d1a1/result.json
@@ -10,24 +10,24 @@
             "img": {
               "description": "Here's the preview for page 0",
               "name": "page_000.png",
-              "sha256": "bf1a066787ad4478325a9f5926ec557997a3421cdf77d7f3d2a3bdecf6a9cfac"
+              "sha256": "1b4c57eba154998ca1e325fdf22121c66668af2c720f0d8a9cb21b606c5440d2"
             },
             "thumb": {
               "description": "Here's the preview for page 0 (thumbnail)",
               "name": "page_000.png.thumb",
-              "sha256": "8dcc7130d6c78beab9f3b95575addfe10b047456e2785cef6835a04cc415f475"
+              "sha256": "0bf41beb8ecebd000e98040aa50181aff7dff38b33cc8e165e4445cf7b1ecdc5"
             }
           },
           {
             "img": {
               "description": "Here's the preview for page 1",
               "name": "page_001.png",
-              "sha256": "6568fff3e8004563387d2dc702dcb200bf21c243cb98723a58b2aea83adfd561"
+              "sha256": "367b7a36301dc8d66ec39081c5624fd6220e7d54f18a6a8b4e32d3788b2e350b"
             },
             "thumb": {
               "description": "Here's the preview for page 1 (thumbnail)",
               "name": "page_001.png.thumb",
-              "sha256": "b87dc10d972b9f8f762e5de5970a2054427203a35409e43305b57e69f8a8eaef"
+              "sha256": "cc5d7a236c69d8200cc33853acd37a2c8f7dc0cc8f32777d3ff558470071cd38"
             }
           }
         ],
@@ -61,20 +61,20 @@
     "extracted": [],
     "supplementary": [
       {
-        "name": "page_001.png",
-        "sha256": "6568fff3e8004563387d2dc702dcb200bf21c243cb98723a58b2aea83adfd561"
-      },
-      {
         "name": "page_000.png.thumb",
-        "sha256": "8dcc7130d6c78beab9f3b95575addfe10b047456e2785cef6835a04cc415f475"
-      },
-      {
-        "name": "page_001.png.thumb",
-        "sha256": "b87dc10d972b9f8f762e5de5970a2054427203a35409e43305b57e69f8a8eaef"
+        "sha256": "0bf41beb8ecebd000e98040aa50181aff7dff38b33cc8e165e4445cf7b1ecdc5"
       },
       {
         "name": "page_000.png",
-        "sha256": "bf1a066787ad4478325a9f5926ec557997a3421cdf77d7f3d2a3bdecf6a9cfac"
+        "sha256": "1b4c57eba154998ca1e325fdf22121c66668af2c720f0d8a9cb21b606c5440d2"
+      },
+      {
+        "name": "page_001.png",
+        "sha256": "367b7a36301dc8d66ec39081c5624fd6220e7d54f18a6a8b4e32d3788b2e350b"
+      },
+      {
+        "name": "page_001.png.thumb",
+        "sha256": "cc5d7a236c69d8200cc33853acd37a2c8f7dc0cc8f32777d3ff558470071cd38"
       }
     ]
   },

--- a/tests/results/4ccd6f19785ef91b358b1c99812e19f30c90d7f43a69b48b5cb39b10a87e695d/result.json
+++ b/tests/results/4ccd6f19785ef91b358b1c99812e19f30c90d7f43a69b48b5cb39b10a87e695d/result.json
@@ -10,12 +10,12 @@
             "img": {
               "description": "Here's the preview for page 0",
               "name": "page_000.png",
-              "sha256": "74e31a854a4ea1f218cd60c5e3b75f40f45bf6b7dad40b0785baf43d0cafff9f"
+              "sha256": "60bca912a7ab0132ac8b18ee37c845f9108f987a28931addbae625538822141d"
             },
             "thumb": {
               "description": "Here's the preview for page 0 (thumbnail)",
               "name": "page_000.png.thumb",
-              "sha256": "19a6b3e98d7ae5d5a50435df59f7af071b12922eaa18e4fb5b87eeb139bed3f4"
+              "sha256": "0a3c327fe116b872952f57d93ac11dfb787e8e986da9d1d914ee430758d270ef"
             }
           }
         ],
@@ -36,11 +36,11 @@
     "supplementary": [
       {
         "name": "page_000.png.thumb",
-        "sha256": "19a6b3e98d7ae5d5a50435df59f7af071b12922eaa18e4fb5b87eeb139bed3f4"
+        "sha256": "0a3c327fe116b872952f57d93ac11dfb787e8e986da9d1d914ee430758d270ef"
       },
       {
         "name": "page_000.png",
-        "sha256": "74e31a854a4ea1f218cd60c5e3b75f40f45bf6b7dad40b0785baf43d0cafff9f"
+        "sha256": "60bca912a7ab0132ac8b18ee37c845f9108f987a28931addbae625538822141d"
       }
     ]
   },

--- a/tests/results/ac7f2627645042190df3244cc25929f4b006d144fc2cac520e79ab376197bbbf/result.json
+++ b/tests/results/ac7f2627645042190df3244cc25929f4b006d144fc2cac520e79ab376197bbbf/result.json
@@ -10,60 +10,60 @@
             "img": {
               "description": "Here's the preview for page 0",
               "name": "page_000.png",
-              "sha256": "217bd8b58a346210fcfae6a92951f1afe5ecb731001cd70d2e840380791ab9f1"
+              "sha256": "df709743eb4d3e2990c546ee41515812806e79b8f8c77638237e2d90de43be88"
             },
             "thumb": {
               "description": "Here's the preview for page 0 (thumbnail)",
               "name": "page_000.png.thumb",
-              "sha256": "e0ceba4920468d7415b04f6be82712ffed487364dd0723a481f5aa900fad4f73"
+              "sha256": "09178a86d3b24ee8a9481389c64a9d111030a7a2a0d6b89f3cca12cc12e7bb55"
             }
           },
           {
             "img": {
               "description": "Here's the preview for page 1",
               "name": "page_001.png",
-              "sha256": "80e77f9ace538377936c3859740288cdb088b78266befd4b14521362dc1db61c"
+              "sha256": "2737cd863922f34fbe8cdf5ca9c868ea87421e6cb1f6ba9b4933798a38e8b6e3"
             },
             "thumb": {
               "description": "Here's the preview for page 1 (thumbnail)",
               "name": "page_001.png.thumb",
-              "sha256": "bae48f22519e544d3693aee07a70fb8efe810b42e594db2b49112d5b236cc4bd"
+              "sha256": "6898e9246c56c646ddf008decaf98d7312227c2662b50b072954dfe3074cbe33"
             }
           },
           {
             "img": {
               "description": "Here's the preview for page 2",
               "name": "page_002.png",
-              "sha256": "226ffc0fb17f6d79978819fa9f34818d5a629893cd0e0000367fbb96e2a1ef05"
+              "sha256": "af440e649f3381a4ee53d95ca3e48091e9bb2e859ba3d3f56309d51dd8fd5e25"
             },
             "thumb": {
               "description": "Here's the preview for page 2 (thumbnail)",
               "name": "page_002.png.thumb",
-              "sha256": "6cfa21f357bb03ea47ff578ea7dd15f9404a2e381006c5916b88be6831c7239f"
+              "sha256": "19aead786cd5ce89cd2a3f2ae0aa4636fc6a9459ca4f10afdeed34e9f6e57211"
             }
           },
           {
             "img": {
               "description": "Here's the preview for page 3",
               "name": "page_003.png",
-              "sha256": "da60eaaf764100ca7aee04e9573a61bb529eb6f85d7420f7b7e523698ea2a474"
+              "sha256": "451c3b34308f0cd89570da08e4187c16b6df4bcb6dc9e8711af94df49252acfa"
             },
             "thumb": {
               "description": "Here's the preview for page 3 (thumbnail)",
               "name": "page_003.png.thumb",
-              "sha256": "d5577256bfe8cf4f20438c6c992e58d88a4749207c52383aa93d119d2cb1f721"
+              "sha256": "a2b6a542eb6f2238e4a67121f76328c72710d1a0ebb9f0f2a6f4e175957953b3"
             }
           },
           {
             "img": {
               "description": "Here's the preview for page 4",
               "name": "page_004.png",
-              "sha256": "472a26a21f5e3366381f6e723c222575a6c529fc2ea5dc2672fc1eae5a0ef472"
+              "sha256": "81403d052c5939779d135b59f6a85e82a32b09796a3cd55bd4a1d796a707a8fc"
             },
             "thumb": {
               "description": "Here's the preview for page 4 (thumbnail)",
               "name": "page_004.png.thumb",
-              "sha256": "f7c7838b385cf286fd8fbd5f28e23527a794052aacadf2630c8e96b8da7812fd"
+              "sha256": "34d0d6c7b84f06d2b344ae181c98e60b4cb36dc74082f29889c5433a9bbe81d3"
             }
           }
         ],
@@ -83,44 +83,44 @@
     "extracted": [],
     "supplementary": [
       {
-        "name": "page_000.png",
-        "sha256": "217bd8b58a346210fcfae6a92951f1afe5ecb731001cd70d2e840380791ab9f1"
-      },
-      {
-        "name": "page_002.png",
-        "sha256": "226ffc0fb17f6d79978819fa9f34818d5a629893cd0e0000367fbb96e2a1ef05"
-      },
-      {
-        "name": "page_004.png",
-        "sha256": "472a26a21f5e3366381f6e723c222575a6c529fc2ea5dc2672fc1eae5a0ef472"
+        "name": "page_000.png.thumb",
+        "sha256": "09178a86d3b24ee8a9481389c64a9d111030a7a2a0d6b89f3cca12cc12e7bb55"
       },
       {
         "name": "page_002.png.thumb",
-        "sha256": "6cfa21f357bb03ea47ff578ea7dd15f9404a2e381006c5916b88be6831c7239f"
+        "sha256": "19aead786cd5ce89cd2a3f2ae0aa4636fc6a9459ca4f10afdeed34e9f6e57211"
       },
       {
         "name": "page_001.png",
-        "sha256": "80e77f9ace538377936c3859740288cdb088b78266befd4b14521362dc1db61c"
-      },
-      {
-        "name": "page_001.png.thumb",
-        "sha256": "bae48f22519e544d3693aee07a70fb8efe810b42e594db2b49112d5b236cc4bd"
-      },
-      {
-        "name": "page_003.png.thumb",
-        "sha256": "d5577256bfe8cf4f20438c6c992e58d88a4749207c52383aa93d119d2cb1f721"
-      },
-      {
-        "name": "page_003.png",
-        "sha256": "da60eaaf764100ca7aee04e9573a61bb529eb6f85d7420f7b7e523698ea2a474"
-      },
-      {
-        "name": "page_000.png.thumb",
-        "sha256": "e0ceba4920468d7415b04f6be82712ffed487364dd0723a481f5aa900fad4f73"
+        "sha256": "2737cd863922f34fbe8cdf5ca9c868ea87421e6cb1f6ba9b4933798a38e8b6e3"
       },
       {
         "name": "page_004.png.thumb",
-        "sha256": "f7c7838b385cf286fd8fbd5f28e23527a794052aacadf2630c8e96b8da7812fd"
+        "sha256": "34d0d6c7b84f06d2b344ae181c98e60b4cb36dc74082f29889c5433a9bbe81d3"
+      },
+      {
+        "name": "page_003.png",
+        "sha256": "451c3b34308f0cd89570da08e4187c16b6df4bcb6dc9e8711af94df49252acfa"
+      },
+      {
+        "name": "page_001.png.thumb",
+        "sha256": "6898e9246c56c646ddf008decaf98d7312227c2662b50b072954dfe3074cbe33"
+      },
+      {
+        "name": "page_004.png",
+        "sha256": "81403d052c5939779d135b59f6a85e82a32b09796a3cd55bd4a1d796a707a8fc"
+      },
+      {
+        "name": "page_003.png.thumb",
+        "sha256": "a2b6a542eb6f2238e4a67121f76328c72710d1a0ebb9f0f2a6f4e175957953b3"
+      },
+      {
+        "name": "page_002.png",
+        "sha256": "af440e649f3381a4ee53d95ca3e48091e9bb2e859ba3d3f56309d51dd8fd5e25"
+      },
+      {
+        "name": "page_000.png",
+        "sha256": "df709743eb4d3e2990c546ee41515812806e79b8f8c77638237e2d90de43be88"
       }
     ]
   },


### PR DESCRIPTION
Based on @kam193's [OOPreview](https://github.com/kam193/assemblyline-services/tree/main/oo-preview) service

- Using OnlyOffice's DocBuilder proves to be faster for processing `document/office/*` files at scale than unoconv & LibreOffice
  - This difference may be due to DocBuilder not having a dependency on the editor to perform file conversions unlike unoconv